### PR TITLE
Fixed issue where the hightlight was highligting the html tag

### DIFF
--- a/src/magicsuggest-1.2.3.js
+++ b/src/magicsuggest-1.2.3.js
@@ -908,11 +908,12 @@
             _renderComboItems: function(items, isGrouped) {
                 var ref = this;
                 $.each(items, function(index, value) {
-                    var displayed = cfg.renderer !== null ? cfg.renderer.call(ref, value) : value[cfg.displayField];
+                    var highlighted = cfg.highlight === true ? self._highlightSuggestion(value[cfg.displayField]) : value[cfg.displayField],
+		                    displayed = cfg.renderer !== null ? cfg.renderer.call(ref, value, highlighted) : highlighted;
                     var resultItemEl = $('<div/>', {
                         'class': 'ms-res-item ' + (isGrouped ? 'ms-res-item-grouped ':'') +
                             (index % 2 === 1 && cfg.useZebraStyle === true ? 'ms-res-odd' : ''),
-                        html: cfg.highlight === true ? self._highlightSuggestion(displayed) : displayed
+                        html: displayed
                     }).data('json', value);
                     resultItemEl.click($.proxy(handlers._onComboItemSelected, ref));
                     resultItemEl.mouseover($.proxy(handlers._onComboItemMouseOver, ref));


### PR DESCRIPTION
Made a change to put in the highlight html before the call to render. My renderer was returning "`<b>beer</b>`".

``` javascript
renderer: function (obj) {
  return obj.isTop ? '<b>' + obj.name + '</b>' : obj.name;
}
```

Since I typed in "b" in the input field the highlighter would return "`< <em>b</em> >beer</b>`"

There is also a new parameter to the render function so that it can have access to the highlighted text. Here is an example of what mine looks like.

``` javascript
renderer: function (obj, highlightedText) {
  return obj.isTop ? '<b>' + highlightedText + '</b>' : highlightedText;
}
```

I couldn't think of a way to make this backwards compatible with the time I had. Thinking about it now that could have probably done a replace.

``` javascript
('<b>beer</b>').replace('beer', '<em>b</em>eer');
```
