### PR TITLE
Fixes a bug with not showing the suggestions dropdown

### DIFF
--- a/src/magicsuggest-1.2.5.js
+++ b/src/magicsuggest-1.2.5.js
@@ -672,7 +672,7 @@
                     resHeight = _comboItemHeight * (data.length + nbGroups);
                 }
 
-                if(resHeight < ms.combobox.height() || resHeight < cfg.maxDropHeight) {
+                if(resHeight < ms.combobox.height() || resHeight <= cfg.maxDropHeight) {
                     ms.combobox.height(resHeight);
                 }
                 else if(resHeight >= ms.combobox.height() && resHeight > cfg.maxDropHeight) {


### PR DESCRIPTION
Unless there was a specific reason for making sure it had to be above or below the maxDropHeight. I fixed this on my local project and it has worked without any errors thus far.
