### PR TITLE
Set the MagicSuggest instance on the new element

### DIFF
--- a/src/magicsuggest-1.2.6.js
+++ b/src/magicsuggest-1.2.6.js
@@ -1412,6 +1412,12 @@
             });
             var field = new MagicSuggest(this, $.extend(options, def));
             cntr.data('magicSuggest', field);
+            
+            // because the object is replace, set the MagicSuggest instance on the new object as well
+            var newcntr = $('#' + cntr.attr('id'));
+            
+            if (newcntr.size() >= 1 && newcntr.eq(0)[0].nodeName !== cntr.eq(0)[0].nodeName)
+                newcntr.data('magicSuggest', field);
         });
 
         if(obj.size() == 1) {


### PR DESCRIPTION
This sets the MagicSuggest instance on the new placed element. 
This is because the new placed element is a different element then the old one.

The following code currently doesn't work:

``` JS
$('#' + txtid).magicSuggest({});

// do something with it
$('#' + txtid).magicSuggest().getValue();
```

This is because the new **div.ms-ctn** will replace the old DOM element when initializing. This patch will solve that problem.

You can see the problem in action using the following link: http://jsfiddle.net/8gFLx/
