### PR TITLE
Fixed 'isSilent' in magicsuggest.clear()

### DIFF
--- a/src/magicsuggest-1.3.0.js
+++ b/src/magicsuggest-1.3.0.js
@@ -469,7 +469,7 @@
          */
         this.clear = function(isSilent)
         {
-            this.removeFromSelection(_selection.slice(0)); // clone array to avoid concurrency issues
+            this.removeFromSelection(_selection.slice(0), isSilent); // clone array to avoid concurrency issues
         };
 
         /**


### PR DESCRIPTION
Clear method was taking the isSilent flag as a parameter, but not using it. Just passed it along to removeFromSelection(), where the 'isSilent' flag was already implemented.
