### PR TITLE
Ajax success callback fixed for jQuery 1.10.2 (Issue #74)

### DIFF
--- a/src/magicsuggest-1.3.0.js
+++ b/src/magicsuggest-1.3.0.js
@@ -417,13 +417,14 @@
              */
             width: function() {
                 return $(this).width();
-            }
+            } ,
 
             /**
-             * @cfg {String} resultField
+             * @cfg {String} resultsField
              * <p>name of JSON object property that represents the list of suggested objects</p>
              * Defaults to <code>results</code>
              */
+            resultsField:'results'
         };
 
         var conf = $.extend({},options);
@@ -846,7 +847,7 @@
                         if(data.length > 0 && typeof(data[0]) === 'string') { // results from array of strings
                             _cbData = self._getEntriesFromStringArray(data);
                         } else { // regular json array or json object with results property
-                            _cbData = data[cfg.resultField] || data;
+                            _cbData = data[cfg.resultsField] || data;
                         }
                     }
                     self._displaySuggestions(self._sortAndTrim(_cbData));


### PR DESCRIPTION
Magicsuggest tries to parse the input parameter of the "success"
callback, but this is already parsed by jQuery resulting in an
exception. This was changed so it only tries to parse the input
parameter when it is a string.
