### PR TITLE
Add ability to specify the delimiter used for displaying selection as a string.

### DIFF
--- a/src/magicsuggest-1.3.1.js
+++ b/src/magicsuggest-1.3.1.js
@@ -293,10 +293,17 @@
 
             /**
              * @cfg {Boolean} resultAsString
-             * <p>Set to true to render selection as comma separated string</p>
+             * <p>Set to true to render selection as delimited string</p>
              * Defaults to <code>false</code>.
              */
             resultAsString: false,
+
+            /**
+             * @cfg {String} resultAsStringDelimiter
+             * <p>Text delimiter to use in a separated string</p>
+             * Defaults to <code>,</code>.
+             */
+            resultAsStringDelimiter: ',',
 
             /**
              * @cfg {String} resultsField
@@ -996,7 +1003,8 @@
              */
             _renderSelection: function() {
                 var ref = this, w = 0, inputOffset = 0, items = [],
-                    asText = cfg.resultAsString === true && !_hasFocus;
+                    asText = cfg.resultAsString === true && !_hasFocus,
+                    asTextDelimiter = cfg.resultAsStringDelimiter;
 
                 ms.selectionContainer.find('.ms-sel-item').remove();
                 if(ms._valueContainer !== undefined) {
@@ -1011,7 +1019,7 @@
                     if(asText === true) {
                         selectedItemEl = $('<div/>', {
                             'class': 'ms-sel-item ms-sel-text ' + cfg.selectionCls,
-                            html: selectedItemHtml + (index === (_selection.length - 1) ? '' : ',')
+                            html: selectedItemHtml + (index === (_selection.length - 1) ? '' : asTextDelimiter)
                         }).data('json', value);
                     }
                     else {


### PR DESCRIPTION
Add ability to specify the delimiter used for displaying selection as a string.

This change introduces a new configuration parameter `resultAsStringDelimiter` to allow the user to specify, if they so choose, a text delimiter other than the default comma. 

I needed this change as I was working with linguistic data and preferred to see the selections as strings, but the commas were causing confusion. This allows me to pass an empty string '' so no delimiter is used, but any text string can be set. It also falls back gracefully in that if `resultAsString` is true, but no special delimiter is specified at all, the original default of a comma is used.
