### PR TITLE
Example 5 - Fixed Data field to be a string

### DIFF
--- a/demo/without plugins/index.html
+++ b/demo/without plugins/index.html
@@ -44,7 +44,7 @@
             });
             var ms5 = $('#ms5').magicSuggest({
                 resultAsString: true,
-                data: ['a,b,c'],
+                data: 'a,b,c',
                 value: ['a','b'],
                 width: 590
             });


### PR DESCRIPTION
In Example 5, the data field was ['a,b,c'] instead of 'a,b,c'. So fixed it.
