### PR TITLE
update bower dependencies

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
     "version": "2.0.4",
     "main": ["magicsuggest.js", "magicsuggest.css"],
     "dependencies": {
-        "bootstrap": "~3.0.2",
+        "bootstrap": "~3",
         "jquery": ">= 1.8.3"
     }
 }


### PR DESCRIPTION
No need to use such a restricted version of the bootstrap specification, it can cause conflicts with other packages.
