### PR TITLE
Add param formatResultAjax for format ajax result when it is String

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -1111,7 +1111,7 @@
                     newSuggestions = [],
                     selectedValues = ms.getValue();
                 // filter the data according to given input
-                if(cfg.useClientFilter && qq.length > 0) {
+                if(cfg.useClientFilter && q.length > 0) {
                     $.each(data, function(index, obj) {
                         var name = obj[cfg.displayField];
                         if((cfg.matchCase === true && name.indexOf(q) > -1) ||


### PR DESCRIPTION
Hello, 

I would suggest an improvement to allow customizing the result of ajax. I have a service that returns json text no. 

To solve my problem, I implemented this change: 

added the default parameter: 

``` javascript
formatResultAjax: function (asyncData) {
   return JSON.parse (asyncData) 
} 
```

And the success of the ajax function _processSuggestions modified the line # 797: 

``` javascript
json = typeof (asyncData) === 'string'? JSON.parse (asyncData): asyncData; 
```

to: 

``` javascript
json = typeof (asyncData) === 'string'? cfg.formatResultAjax (asyncData): asyncData;
```
