### PR TITLE
Added escaping special regex characters

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -717,6 +717,14 @@
              */
             _highlightSuggestion: function(html) {
                 var q = ms.input.val();
+
+                //escape special regex characters
+                var specialCharacters = ['^', '$', '*', '+', '?', '.', '(', ')', ':', '!', '|', '{', '}', '[', ']'];
+
+                $.each(specialCharacters, function (index, value) {
+                    q = q.replace(value, "\\" + value);
+                })
+
                 if(q.length === 0) {
                     return html; // nothing entered as input
                 }


### PR DESCRIPTION
I was working on a website that had entries with names that include parenthesized information and magicsuggest wouldn't highlight anything after a special parenthesis. I thought it was a tiny fix that could go into the next release or something.

I expanded it for all the special characters to keep the regex from breaking at all in the _highlightSuggestion method.
