### PR TITLE
Add 3 features to magicsuggest (Now 4)

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -706,8 +706,14 @@
                     ms.collapse();
                 }
 
-                if(data.length === 0){
-                    ms.combobox.hide();
+                // When free entry is off, add invalid class to input if no data matches
+                if(cfg.allowFreeEntries === false) {
+                  if(data.length === 0) {
+                      $(ms.input).addClass(cfg.invalidCls);
+                      ms.combobox.hide();
+                  } else {
+                    $(ms.input).removeClass(cfg.invalidCls);
+                  }
                 }
             },
 


### PR DESCRIPTION
Hello,

This pull request adds three features:
1. Allow the customization of the query parameter sent. (We needed it to be "q" rather than "query")
2. We needed to auto select the first element even when there are multiple results.
3. We wanted to be able to customize the text shown when there were no results to include the query.

I didn't re-minify the js though. I wasn't sure if you had a special way/tool you used to do that.

Cheers!
