### PR TITLE
_renderSelection is now triggered when the browser window is resized

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -953,6 +953,8 @@
                     ms.container.append(ms.trigger);
                 }
 
+                $(window).resize($.proxy(handlers._onWindowResized, this));
+
                 // do not perform an initial call if we are using ajax unless we have initial values
                 if(cfg.value !== null || cfg.data !== null){
                     if(typeof(cfg.data) === 'string'){
@@ -1496,6 +1498,14 @@
                         }
                     }
                 }
+            },
+
+            /**
+             * Triggered when the browser window is resized
+             * @private
+             */
+            _onWindowResized: function() {
+                self._renderSelection();
             }
         };
 


### PR DESCRIPTION
this is so the magic suggest layout doesn't break

resizing the browser window used to break the layout (when there were items selected) due to the input not resizing.
