### PR TITLE
The input become invisible when the row is filled

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -1073,6 +1073,9 @@
                     ms.input.width(0);
                     inputOffset = ms.input.offset().left - ms.selectionContainer.offset().left;
                     w = ms.container.width() - inputOffset - 42;
+                    if(w < 0) {
+                        w = ms.container.width();
+                    }
                     ms.input.width(w);
                 }
 


### PR DESCRIPTION
In case the selected items fill up the whole first row, the resulting width becomes negative.

This will only make the input the same size as container.
