### PR TITLE
Don't do initial AJAX request if value is not set.

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -956,7 +956,7 @@
                 $(window).resize($.proxy(handlers._onWindowResized, this));
 
                 // do not perform an initial call if we are using ajax unless we have initial values
-                if(cfg.value !== null || cfg.data !== null){
+                if(cfg.value !== null && cfg.data !== null){
                     if(typeof(cfg.data) === 'string'){
                         self._asyncValues = cfg.value;
                         self._processSuggestions();


### PR DESCRIPTION
Currently if you have `data` property set, MagicSuggest will do initial AJAX request no matter if you set up `value` property or not.

This PR should fix that issue.
