### PR TITLE
fix input placeholder bug

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -550,6 +550,7 @@
                 }
             }
             this.input.attr('placeholder', (cfg.selectionPosition === 'inner' && this.getValue().length > 0) ? '' : cfg.placeholder);
+            this.input.css({width: '100%'});
         };
 
         /**


### PR DESCRIPTION
fix bug 
after call the clear() function . the input placeholder can't be shown totally. i see the input width has been changed too small after call clear. so i change the input width.

![image](https://cloud.githubusercontent.com/assets/3774935/8588990/724e0c6a-2643-11e5-901c-2689a6c04e79.png)
![image](https://cloud.githubusercontent.com/assets/3774935/8588992/79df00ce-2643-11e5-925f-cbdb54674cdf.png)
