### PR TITLE
Stop errors

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -973,8 +973,8 @@
                 $("body").click(function(e) {
                     if(ms.container.hasClass('ms-ctn-focus') &&
                         ms.container.has(e.target).length === 0 &&
-                        e.target.className.indexOf('ms-res-item') < 0 &&
-                        e.target.className.indexOf('ms-close-btn') < 0 &&
+                        (e.target.className || '').indexOf('ms-res-item') < 0 &&
+                        (e.target.className || '').indexOf('ms-close-btn') < 0 &&
                         ms.container[0] !== e.target) {
                         handlers._onBlur();
                     }

--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -973,8 +973,8 @@
                 $("body").click(function(e) {
                     if(ms.container.hasClass('ms-ctn-focus') &&
                         ms.container.has(e.target).length === 0 &&
-                        (e.target.className || '').indexOf('ms-res-item') < 0 &&
-                        (e.target.className || '').indexOf('ms-close-btn') < 0 &&
+                        $(e.target).attr('class').indexOf('ms-res-item') < 0 &&
+                        $(e.target).attr('class').indexOf('ms-close-btn') < 0 &&
                         ms.container[0] !== e.target) {
                         handlers._onBlur();
                     }


### PR DESCRIPTION
Not sure if this is the best way to do this, but I have a situation where we use magic suggest to capture a click event within the magic suggest ui, then do an action from our app. This global listener on body is then throwing errors on the first click after the click in magic suggest. There is no guarantee that `e.target` is a string as far as I can tell. It would seem to me a `$('body').on(someNamespacedEventThatCouldBeCleanedUp, 'click')` would be a better approach possibly? I can get you a video of what is happening but it'd take me some work since we're using this in a non-public setting. Thank you
