### PR TITLE
Prepend close button instead of appending it

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -1045,7 +1045,7 @@
                             // small cross img
                             delItemEl = $('<span/>', {
                                 'class': 'ms-close-btn'
-                            }).data('json', value).appendTo(selectedItemEl);
+                            }).data('json', value).prependTo(selectedItemEl);
 
                             delItemEl.click($.proxy(handlers._onTagTriggerClick, ref));
                         }


### PR DESCRIPTION
It is more correct to prepend a floating element than to append it. When you append it you can sometimes run into issues.

For example, here is what happens if you wrap the output in a div using the `selectionRenderer` callback:

![image](https://user-images.githubusercontent.com/6479817/28096300-95dd02fc-665c-11e7-8fd1-abf4771eda05.png)

And after changing it to prepend:

![image](https://user-images.githubusercontent.com/6479817/28096313-af7c25bc-665c-11e7-937f-53d924e7620c.png)