### PR TITLE
add 'error' event to allow users handle errors

### DIFF
--- a/magicsuggest.js
+++ b/magicsuggest.js
@@ -835,8 +835,8 @@
                                     delete(self._asyncValues);
                                 }
                             },
-                            error: function(){
-                                throw("Could not reach server");
+                            error: function( jqXHR, textStatus, errorThrown){
+                                $(ms).trigger('error', [ms, jqXHR, textStatus, errorThrown]);
                             }
                         }, cfg.ajaxConfig));
                         return;


### PR DESCRIPTION
Instead of throwing the error, add error event to allow users to handle the error with customize actions.